### PR TITLE
Fix datagram destination to use the host/port provided to DefaultSocketProvider

### DIFF
--- a/src/main/java/com/studyblue/metrics/reporting/StatsdReporter.java
+++ b/src/main/java/com/studyblue/metrics/reporting/StatsdReporter.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
-import java.net.InetSocketAddress;
+import java.net.InetAddress;
 import java.util.Locale;
 import java.util.Map;
 import java.util.SortedMap;
@@ -304,7 +304,7 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
                 statTypeStr = "ms";
                 break;
         }
-        
+
         try {
             if (!prefix.isEmpty()) {
                 writer.write(prefix);
@@ -333,19 +333,25 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
 
         @Override
         public DatagramSocket get() throws Exception {
-            return new DatagramSocket(new InetSocketAddress(this.host, this.port));
+            return new DatagramSocket();
         }
-        
+
         @Override
         public DatagramPacket newPacket(ByteArrayOutputStream out) {
             byte[] dataBuffer;
+
             if (out != null) {
                 dataBuffer = out.toByteArray();
             }
             else {
                 dataBuffer = new byte[8192];
             }
-            return new DatagramPacket(dataBuffer, dataBuffer.length);
+
+            try {
+                return new DatagramPacket(dataBuffer, dataBuffer.length, InetAddress.getByName(this.host), this.port);
+            } catch (Exception e) {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
- Use default constructor for DatagramSocket. Previously the host/port were
  passed to DatagramSocket to be used as the locally-bound address.
- Set the destination host/port in the DatagramPacket constructor. Previously
  the DatagramPacket was being constructed with no destination.
- Add import of java.net.InetAddress, remove import of java.net.InetSocketAddress.

http://docs.oracle.com/javase/6/docs/api/java/net/DatagramSocket.html#DatagramSocket()
http://docs.oracle.com/javase/6/docs/api/java/net/DatagramPacket.html#DatagramPacket(byte[], int, java.net.InetAddress, int)
