### PR TITLE
Remove references to Graphite and add a quick start section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Statsd reporter for codahale/metrics.
 
+## Quick Start
+
+```java
+MetricsRegistry registry = new MetricsRegistry();
+StatsdReporter reporter = new StatsdReporter(registry, "statsd.example.com", 8125);
+reporter.start();
+```
+
 ## Important Notes
 
 ### Package Name & GroupId

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Statsd reporter for codahale/metrics.
 ```java
 MetricsRegistry registry = new MetricsRegistry();
 StatsdReporter reporter = new StatsdReporter(registry, "statsd.example.com", 8125);
-reporter.start();
+reporter.start(15, TimeUnit.SECONDS);
 ```
 
 ## Important Notes

--- a/src/main/java/com/bealetech/metrics/reporting/StatsdReporter.java
+++ b/src/main/java/com/bealetech/metrics/reporting/StatsdReporter.java
@@ -79,7 +79,7 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
     }
 
     public StatsdReporter(MetricsRegistry metricsRegistry, String prefix, MetricPredicate predicate, UDPSocketProvider socketProvider, Clock clock, VirtualMachineMetrics vm) throws IOException {
-        this(metricsRegistry, prefix, predicate, socketProvider, clock, vm, "graphite-reporter");
+        this(metricsRegistry, prefix, predicate, socketProvider, clock, vm, "statsd-reporter");
     }
 
     public StatsdReporter(MetricsRegistry metricsRegistry, String prefix, MetricPredicate predicate, UDPSocketProvider socketProvider, Clock clock, VirtualMachineMetrics vm, String name) throws IOException {
@@ -130,9 +130,9 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
             socket.send(packet);
         } catch (Exception e) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Error writing to Graphite", e);
+                LOG.debug("Error writing to StatsD", e);
             } else {
-                LOG.warn("Error writing to Graphite: {}", e.getMessage());
+                LOG.warn("Error writing to StatsD: {}", e.getMessage());
             }
             if (writer != null) {
                 try {
@@ -322,7 +322,7 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
             prependNewline = true;
             writer.flush();
         } catch (IOException e) {
-            LOG.error("Error sending to Graphite:", e);
+            LOG.error("Error sending to StatsD:", e);
         }
     }
 


### PR DESCRIPTION
Replaced references to Graphite with StatsD and added a section to the README to help users who are new to using Metrics plugins get an idea of how to use the API.
