### PR TITLE
Add option for disabling the double translation of timer metrics in statsd

### DIFF
--- a/src/main/java/com/bealetech/metrics/reporting/StatsdReporter.java
+++ b/src/main/java/com/bealetech/metrics/reporting/StatsdReporter.java
@@ -48,7 +48,7 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
 
     private boolean prependNewline = false;
     private boolean printVMMetrics = true;
-    private boolean shouldTranslateTimersToGauges = true; // Statsd rewrites timers with more info, causing a potential explosion in
+    private boolean shouldTranslateTimersToGauges = false; // Statsd rewrites timers with more info, causing a potential explosion in
                                              // the number of metrics being pushed from statsd to graphite if you have a
                                              // lot of timers or histograms. See: https://github.com/etsy/statsd/blob/master/docs/metric_types.md#timing
 

--- a/src/main/java/com/bealetech/metrics/reporting/StatsdReporter.java
+++ b/src/main/java/com/bealetech/metrics/reporting/StatsdReporter.java
@@ -48,6 +48,9 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
 
     private boolean prependNewline = false;
     private boolean printVMMetrics = true;
+    private boolean shouldTranslateTimersToGauges = true; // Statsd rewrites timers with more info, causing a potential explosion in
+                                             // the number of metrics being pushed from statsd to graphite if you have a
+                                             // lot of timers or histograms. See: https://github.com/etsy/statsd/blob/master/docs/metric_types.md#timing
 
     public interface UDPSocketProvider {
         DatagramSocket get() throws Exception;
@@ -106,6 +109,14 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
 
     public void setPrintVMMetrics(boolean printVMMetrics) {
         this.printVMMetrics = printVMMetrics;
+    }
+
+    public boolean isShouldTranslateTimersToGauges() {
+        return shouldTranslateTimersToGauges;
+    }
+
+    public void setShouldTranslateTimersToGauges(boolean shouldTranslateTimersToGauges) {
+        this.shouldTranslateTimersToGauges = shouldTranslateTimersToGauges;
     }
 
     @Override
@@ -303,7 +314,7 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
                 statTypeStr = "g";
                 break;
             case TIMER:
-                statTypeStr = "ms";
+                statTypeStr = shouldTranslateTimersToGauges ? "g" : "ms";
                 break;
         }
 


### PR DESCRIPTION
When a "Gauge" (in statsd lingo) is sent over, statsd will compute a bunch of trends and percentile calculations for each metric.  With Yammer Metrics timers and histograms, those calculations are already there, so there is no need for statsd to calculate them again.  

This commit provides an option that allows statsd to just take the metrics as provided by the metrics registry and pass them along to graphite un-altered.

This commit is backwards compatible.

If merged, please kindly perform a new 2.3.1 release to maven central. 
