### PR TITLE
Updating metrics to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Releases: [https://oss.sonatype.org/content/groups/public](https://oss.sonatype.
     <td><strong>metrics version</strong></td> 
   </tr>
   <tr>
+    <td>3.1.x</td>
+    <td>3.1.0</td>
+  </tr>
+  <tr>
     <td>3.0.x</td>
     <td>3.0.1</td>
   </tr>

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
     <groupId>com.bealetech</groupId>
     <artifactId>metrics-statsd</artifactId>
     <name>Metrics Statsd Support</name>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>http://github.com/organicveggie/metrics-statsd/</url>
     <description>Statsd reporter for codahale/metrics.</description>
 
     <properties>
-        <metrics.version>3.0.1</metrics.version>
-        <slf4j.version>1.7.5</slf4j.version>
+        <metrics.version>3.1.0</metrics.version>
+        <slf4j.version>1.7.7</slf4j.version>
     </properties>
 
     <developers>
@@ -59,7 +59,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${metrics.version}</version>
             <type>jar</type>


### PR DESCRIPTION
I've bumped to 3.1.0-SNAPSHOT, but a release of this as 3.1.0 would be really handy.
